### PR TITLE
Adding panning functionality #10

### DIFF
--- a/src/diagram.js
+++ b/src/diagram.js
@@ -104,6 +104,27 @@ function makePaper (element) {
       useLinkTools: false
     }
   })
+  
+  // panning functionality
+  var dragStartPosition = null;
+  paper.on("blank:pointerdown", function (evt, x, y) {
+    var scale = paper.scale()
+    
+    dragStartPosition = { x: x * scale.sx, y: y * scale.sy };
+  })
+
+  paper.on("cell:pointerup blank:pointerup", function (cellView, x, y) {
+      dragStartPosition = null;
+  })
+
+  $("#diagram").mousemove(function (event) {
+    if (dragStartPosition != null) {
+        paper.translate(
+            event.offsetX - dragStartPosition.x,
+            event.offsetY - dragStartPosition.y);
+    }
+  });
+  
   // Create a adjustGraphVertices() function to wrap the
   //   multipleLinks.adjustVertices function.
   // The new adjustGraphVertices() function automatically passes in the graph


### PR DESCRIPTION
So the first solution on this [StackOverflow](https://stackoverflow.com/questions/28431384/how-to-make-a-paper-draggable) article worked. It even accounts for the zoom functionality you've done using `paper.scale()`. I tested it and it works great.
I made the changes in diagram.js 